### PR TITLE
Publish v1.64.0. [release]

### DIFF
--- a/1.64/Dockerfile
+++ b/1.64/Dockerfile
@@ -1,0 +1,19 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV RUST_VERSION=1.64.0 \
+	PATH=/home/circleci/.cargo/bin:$PATH
+
+RUN curl -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
+	chmod +x rustup-init && \
+	./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION && \
+	rm rustup-init && \
+	rustc --version && \
+	cargo --version
+
+RUN rustup component add rustfmt

--- a/1.64/browsers/Dockerfile
+++ b/1.64/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/rust:1.64.0-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.64/node/Dockerfile
+++ b/1.64/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/rust:1.64.0
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 1.63/Dockerfile -t cimg/rust:1.63.0  -t cimg/rust:1.63 .
-docker build --file 1.63/node/Dockerfile -t cimg/rust:1.63.0-node  -t cimg/rust:1.63-node .
-docker build --file 1.63/browsers/Dockerfile -t cimg/rust:1.63.0-browsers  -t cimg/rust:1.63-browsers .
+docker build --file 1.64/Dockerfile -t cimg/rust:1.64.0  -t cimg/rust:1.64 .
+docker build --file 1.64/node/Dockerfile -t cimg/rust:1.64.0-node  -t cimg/rust:1.64-node .
+docker build --file 1.64/browsers/Dockerfile -t cimg/rust:1.64.0-browsers  -t cimg/rust:1.64-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker push cimg/rust:1.63.0
-docker push cimg/rust:1.63
-docker push cimg/rust:1.63.0-node
-docker push cimg/rust:1.63-node
-docker push cimg/rust:1.63.0-browsers
-docker push cimg/rust:1.63-browsers
+docker push cimg/rust:1.64.0
+docker push cimg/rust:1.64
+docker push cimg/rust:1.64.0-node
+docker push cimg/rust:1.64-node
+docker push cimg/rust:1.64.0-browsers
+docker push cimg/rust:1.64-browsers


### PR DESCRIPTION
[Rust v1.64.0](https://github.com/rust-lang/rust/releases/tag/1.64.0) was released, but cimg/rust:1.64.0 isn't yet.
And it was fixed CVE-2022-36113 and CVE-2022-36114. ( by [this PR](https://github.com/rust-lang/cargo/pull/11088) )

(I ran only `./shared/gen-dockerfiles.sh 1.64.0` in root.)

Last but not least, I apologize for my poor English.