### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,7 +13,8 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 ENV RUST_VERSION=%%VERSION_FULL%% \
 	PATH=/home/circleci/.cargo/bin:$PATH
 
-RUN curl -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x86_64" || ARCH="aarch64" && \
+	curl -O https://static.rust-lang.org/rustup/dist/${ARCH}-unknown-linux-gnu/rustup-init && \
 	chmod +x rustup-init && \
 	./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION && \
 	rm rustup-init && \

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=rust
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch check for the rustup script download

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-rust/1067/workflows/e2ac4038-cd3e-48a6-b53c-6ec9ebecfaa4/jobs/2461

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
