### PR TITLE
Update cimg/base

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2024.02
+FROM cimg/%%PARENT%%:2026.03-22.04
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Updates the cimg/base versions to the latest available.